### PR TITLE
PR: 바텀 네비게이션 Badge 속성 추가 및 관리 & 간단한 refactor

### DIFF
--- a/app/src/main/java/com/example/spoot_taxi_front/activities/ChatRoomActivity.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/activities/ChatRoomActivity.java
@@ -57,7 +57,6 @@ public class ChatRoomActivity extends AppCompatActivity {
     private Long chatRoomId;
     private Long chatParticipantId;
     private List<ChatMessage> chatMessageList = new ArrayList<>();
-
     private ChatApi chatApi;
 
     @Override
@@ -65,33 +64,30 @@ public class ChatRoomActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_chat_room);
 
-        //메뉴를 위한 툴바 설정, title을 false안하면 기본 디폴트타이틀이 보이게됨
+        /**===============요소들 초기화 및 설정==================**/
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayShowTitleEnabled(false);
-
-        // -1은 기본값
         chatRoomId = getIntent().getLongExtra("chatRoomId", -1);
-        Log.d("채팅방 id", chatRoomId.toString());
-
-        //웹소켓매니저 가져오기
-        //webSocketViewModel = new ViewModelProvider(this).get(WebSocketViewModel.class);
         webSocketViewModel = WebSocketViewModel.getInstance();
+
         // 레이아웃 요소 초기화
         recyclerViewChat = findViewById(R.id.recyclerViewChat);
         editTextMessage = findViewById(R.id.editTextMessage);
         buttonSend = findViewById(R.id.buttonSend);
         buttonScrollToBottom = findViewById(R.id.buttonScrollToBottom);
         newMsgButton = findViewById(R.id.newMsgButton);
+
         // RecyclerView 설정
         LinearLayoutManager layoutManager = new LinearLayoutManager(this);
         layoutManager.setStackFromEnd(true);
         recyclerViewChat.setLayoutManager(layoutManager);
         messageAdapter = new MessageAdapter();
         recyclerViewChat.setAdapter(messageAdapter);
-        //시작할 경우에 스크롤 버튼 꺼놓기
         buttonScrollToBottom.setVisibility(View.GONE);
         newMsgButton.setVisibility(View.GONE);
+
+        /**===============Listeners==================**/
         recyclerViewChat.addOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override
             public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
@@ -107,7 +103,6 @@ public class ChatRoomActivity extends AppCompatActivity {
             }
         });
 
-        //스크롤 버튼
         buttonScrollToBottom.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -115,17 +110,14 @@ public class ChatRoomActivity extends AppCompatActivity {
             }
         });
 
-        //newMsg알림 버튼
         newMsgButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 recyclerViewChat.smoothScrollToPosition(messageAdapter.getItemCount() - 1);
             }
         });
-        // 전송 버튼 초기 상태를 비활성화로 설정
         buttonSend.setEnabled(false);
 
-        // editText의 텍스트 변화를 감지하는 TextWatcher 설정
         editTextMessage.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {
@@ -146,7 +138,6 @@ public class ChatRoomActivity extends AppCompatActivity {
             }
         });
 
-        // 전송 버튼 클릭 리스너 설정
         buttonSend.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -159,7 +150,7 @@ public class ChatRoomActivity extends AppCompatActivity {
             }
         });
 
-        // 채팅 데이터 가져오기 (서버와의 연동 필요)
+        /**===============Data Setting==================**/
         chatApi = ApiManager.getInstance().createChatApi(SessionManager.getInstance().getJwtToken());
         Call<ChatRoomMessageResponse> chatRoomMessages = chatApi.getChatRoomMessages(chatRoomId,SessionManager.getInstance().getCurrentUser().getEmail());
         chatRoomMessages.enqueue(new Callback<ChatRoomMessageResponse>() {
@@ -207,7 +198,7 @@ public class ChatRoomActivity extends AppCompatActivity {
         //messageAdapter.setChatMessages(chatMessageList);
     }
 
-    //나가기 버튼을 위해서 메뉴ActionBar inflate해줌
+    /**===============생명주기 메서드들==================**/
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuInflater inflater = getMenuInflater();
@@ -218,7 +209,6 @@ public class ChatRoomActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        // 스크롤을 맨 아래로 이동
         scrollToBottom();
     }
 
@@ -281,6 +271,8 @@ public class ChatRoomActivity extends AppCompatActivity {
         return super.onOptionsItemSelected(item);
     }
 
+
+    /**===============일반 메서드들==================**/
     private void handleChatRoomMessageResponse(int statusCode, ChatRoomMessageResponse responseBody) {
         switch (statusCode) {
             case 200:

--- a/app/src/main/java/com/example/spoot_taxi_front/activities/ChatRoomActivity.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/activities/ChatRoomActivity.java
@@ -31,7 +31,7 @@ import com.example.spoot_taxi_front.network.dto.responses.UpdateChatParticipantR
 import com.example.spoot_taxi_front.network.retrofit.ApiManager;
 import com.example.spoot_taxi_front.utils.LocalChatRoomManager;
 import com.example.spoot_taxi_front.utils.SessionManager;
-import com.example.spoot_taxi_front.utils.WebSocketViewModel;
+import com.example.spoot_taxi_front.network.socket.WebSocketViewModel;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/app/src/main/java/com/example/spoot_taxi_front/activities/JoinActivity.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/activities/JoinActivity.java
@@ -50,18 +50,11 @@ import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 
-/**
- * authController에 noreply 재학생 인증 api 추가 필요
- * authController에 이미 존재하는 아이디인지 확인하는 api 추가 필요
- * entity 속성 정립 해야 함 -> 근데 하면서 하게 될 듯
- */
 public class JoinActivity extends AppCompatActivity {
 
 
     private ActivityJoinBinding binding;
-    private static final int PICK_IMAGE_REQUEST_CODE = 1;
     private static final int ALBUM_PERMISSION_REQUEST_CODE = 1; // 앨범 접근 권한 요청 코드
-    private static final int ALBUM_REQUEST_CODE = 2; // 앨범 액티비티 호출 요청 코드
     private static final String DEFAULT_PROFILE_IMAGE_URL = "http://192.168.219.110:8080/api/images/profile-image/default-profile-image.jpg";
 
     //회원가입에 기입할 정보들
@@ -120,7 +113,6 @@ public class JoinActivity extends AppCompatActivity {
                     if (ContextCompat.checkSelfPermission(JoinActivity.this, Manifest.permission.READ_MEDIA_IMAGES) != PackageManager.PERMISSION_GRANTED) {
                         // 권한이 없는 경우 권한 요청
                         ActivityCompat.requestPermissions(JoinActivity.this, new String[]{Manifest.permission.READ_MEDIA_IMAGES}, ALBUM_PERMISSION_REQUEST_CODE);
-
                     } else {
                         // 이미 권한이 있는 경우 앨범 액티비티 호출
                         galleryLauncher.launch("image/*");
@@ -144,7 +136,6 @@ public class JoinActivity extends AppCompatActivity {
 
         // 회원가입 버튼 클릭
         binding.joinButton.setOnClickListener(new View.OnClickListener() {
-
             @Override
             public void onClick(View view) {
                 // 모든 입력란(Edit Text)에 대해 작성란이 비어있거나 format이 올바른지 확인
@@ -159,7 +150,6 @@ public class JoinActivity extends AppCompatActivity {
         binding.cancelBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-
                 //로그인 화면으로 이동
                 Intent intent = new Intent(getApplicationContext(), LoginActivity.class);
                 startActivity(intent);

--- a/app/src/main/java/com/example/spoot_taxi_front/activities/JoinActivity.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/activities/JoinActivity.java
@@ -55,7 +55,7 @@ public class JoinActivity extends AppCompatActivity {
 
     private ActivityJoinBinding binding;
     private static final int ALBUM_PERMISSION_REQUEST_CODE = 1; // 앨범 접근 권한 요청 코드
-    private static final String DEFAULT_PROFILE_IMAGE_URL = "http://192.168.219.110:8080/api/images/profile-image/default-profile-image.jpg";
+    private static final String DEFAULT_PROFILE_IMAGE_URL = "http://192.168.219.110:8080/api/images/default-profile-image.jpg";
 
     //회원가입에 기입할 정보들
     private String email;

--- a/app/src/main/java/com/example/spoot_taxi_front/activities/MainActivity.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/activities/MainActivity.java
@@ -59,9 +59,9 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        EventBus.getDefault().register(this);
         localChatRoomManager = LocalChatRoomManager.getInstance();
         binding = ActivityMainBinding.inflate(getLayoutInflater());
-        EventBus.getDefault().register(this);
         setContentView(binding.getRoot());
 
         localChatRoomManager.loadChatRoomsFromServer();
@@ -121,7 +121,6 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
-
         // EventBus 해제
         EventBus.getDefault().unregister(this);
     }

--- a/app/src/main/java/com/example/spoot_taxi_front/activities/MainActivity.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/activities/MainActivity.java
@@ -2,7 +2,6 @@ package com.example.spoot_taxi_front.activities;
 
 import static android.app.PendingIntent.getActivity;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -10,13 +9,8 @@ import androidx.fragment.app.FragmentTransaction;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
 import android.util.Log;
 import android.view.MenuItem;
-import android.view.View;
-import android.widget.Button;
-import android.widget.Toast;
 
 
 import com.example.spoot_taxi_front.databinding.ActivityMainBinding;
@@ -28,13 +22,8 @@ import com.example.spoot_taxi_front.fragments.SettingsFragment;
 
 
 import com.example.spoot_taxi_front.utils.LocalChatRoomManager;
-import com.example.spoot_taxi_front.utils.NewMessageEvent;
-import com.example.spoot_taxi_front.utils.NonReadCountUpdateEvent;
-import com.example.spoot_taxi_front.utils.SessionManager;
-import com.google.android.gms.tasks.OnCompleteListener;
-import com.google.android.gms.tasks.Task;
+import com.example.spoot_taxi_front.utils.ChatRoomDataChange;
 import com.google.android.material.badge.BadgeDrawable;
-import com.google.firebase.messaging.FirebaseMessaging;
 import com.kakao.util.maps.helper.Utility;
 
 import org.greenrobot.eventbus.EventBus;
@@ -127,7 +116,7 @@ public class MainActivity extends AppCompatActivity {
 
 
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onNewMessageArrived(NonReadCountUpdateEvent event) {
+    public void onNewMessageArrived(ChatRoomDataChange event) {
         Log.d("BadgeUpdate", "onNewMessageArrived: ");
         int totalNonReadCount = localChatRoomManager.getTotalNonReadCount();
         if (totalNonReadCount > 0) {

--- a/app/src/main/java/com/example/spoot_taxi_front/activities/PasswordResetActivity.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/activities/PasswordResetActivity.java
@@ -102,8 +102,6 @@ public class PasswordResetActivity extends AppCompatActivity {
                 break;
             default:
                 Toast.makeText(getApplicationContext(), "비밀번호 재설정에 실패하였습니다.", Toast.LENGTH_SHORT).show();
-                Toast.makeText(getApplicationContext(), "비밀번호 재설정에 실패하였습니다." + statusCode, Toast.LENGTH_SHORT).show();
-
                 break;
 
         }

--- a/app/src/main/java/com/example/spoot_taxi_front/activities/UpdateActivity.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/activities/UpdateActivity.java
@@ -55,7 +55,7 @@ public class UpdateActivity extends AppCompatActivity {
     private ActivityUpdateBinding binding;
     private static final int ALBUM_PERMISSION_REQUEST_CODE = 1; // 앨범 접근 권한 요청 코드
     private static final int ALBUM_REQUEST_CODE = 2; // 앨범 액티비티 호출 요청 코드
-
+    private static final String DEFAULT_PROFILE_IMAGE_URL = "http://192.168.219.110:8080/api/images/default-profile-image.jpg";
 
     private String email;
     private String password;
@@ -77,11 +77,8 @@ public class UpdateActivity extends AppCompatActivity {
         authApi = ApiManager.getInstance().createAuthApi(SessionManager.getInstance().getJwtToken());
         //현재 유저정보로 Edit Text 채워놓기
         User currentUser = SessionManager.getInstance().getCurrentUser();
-
         binding.inputEmail.setText(currentUser.getEmail());
-//        binding.profileImageView.setImageURI(Uri.parse(currentUser.getImgUrl()));
-//        binding.profileImageView.setImageURI(Uri.parse("http://192.168.219.110:8080/api/images/profile-image/file_20230731_195748_7305.jpg"));
-        Glide.with(this).load("http://192.168.219.110:8080/api/images/profile-image/file_20230731_195748_7305.jpg").into(binding.profileImageView);
+        Glide.with(this).load(SessionManager.getInstance().getCurrentUser().getImgUrl()).into(binding.profileImageView);
         binding.inputPassword.setText(currentUser.getPassword());
         binding.inputPwck.setText(currentUser.getPassword());
         binding.inputNickname.setText(currentUser.getNickname());
@@ -146,35 +143,8 @@ public class UpdateActivity extends AppCompatActivity {
 
             @Override
             public void onClick(View view) {
-
-
                 if (!chcekUpdateInputs()) return;
-
-//                //모든 체크 사항 통과
-//                //User 초기화 및 업데이트 요청
-//                email = binding.inputEmail.getText().toString();
-//                password = binding.inputPassword.getText().toString();
-//                nickname = binding.inputNickname.getText().toString();
-//                RadioGroup radioGroup = binding.inputGender;
-//                int selectedId = radioGroup.getCheckedRadioButtonId();
-//
-//                RadioButton radioButton = findViewById(selectedId);
-//                String gender = radioButton.getText().toString();
-//
-//                if (gender.equals("여성")) {
-//                    gen = Gender.FEMALE;
-//                } else if (gender.equals("남성")) {
-//                    gen = Gender.MALE;
-//                } else {
-//                    gen = Gender.ETC;
-//                }
-
                 updateProcess();
-                //유저 초기화
-                User user = new User(email, password, nickname, imgUrl, gen);
-                //update user api
-
-
             }
         });
 
@@ -255,7 +225,6 @@ public class UpdateActivity extends AppCompatActivity {
     private void updateProcess() {
 
         //프로필 이미지를 선택했다면 프로필 이미지를 서버에 업로드
-        //imgUrl을 받아온 후 imgurl 정보를 포함시켜 회원가입을 요청한다.
         if (imageFile != null) {
 
             //가입에 요청할 유저 정보를 EditText에서 받아옴

--- a/app/src/main/java/com/example/spoot_taxi_front/activities/VerificationActivity.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/activities/VerificationActivity.java
@@ -62,9 +62,6 @@ public class VerificationActivity extends AppCompatActivity {
 
                 String email = binding.emailEdt.getText().toString();
 
-
-
-
                 Call<EmailVerificationResponse> sendVerificationEmailCall = authApi.sendVerificationEmailForJoin(email, false);
                 sendVerificationEmailCall.enqueue(new Callback<EmailVerificationResponse>() {
                     @Override

--- a/app/src/main/java/com/example/spoot_taxi_front/fragments/ChatFragment.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/fragments/ChatFragment.java
@@ -21,6 +21,7 @@ import com.example.spoot_taxi_front.network.dto.UserDto;
 import com.example.spoot_taxi_front.network.dto.UserJoinedChatRoomDto;
 import com.example.spoot_taxi_front.network.dto.responses.UserJoinedChatRoomResponse;
 import com.example.spoot_taxi_front.network.retrofit.ApiManager;
+import com.example.spoot_taxi_front.utils.ChatRoomDataChange;
 import com.example.spoot_taxi_front.utils.LocalChatRoomManager;
 import com.example.spoot_taxi_front.utils.NewMessageEvent;
 import com.example.spoot_taxi_front.utils.SessionManager;
@@ -45,30 +46,10 @@ public class ChatFragment extends Fragment {
     private RecyclerView chatRecyclerView;
     private ChatRoomAdapter chatRoomAdapter;
     private WebSocketViewModel webSocketViewModel;
-    private ChatApi chatApi;
-    private List<ChatRoom> chatRoomList = new ArrayList<>();
     private LocalChatRoomManager localChatRoomManager;
 
     public ChatFragment() {
-        // Required empty public constructor
     }
-
-    @Override
-    public void onHiddenChanged(boolean hidden) {
-        super.onHiddenChanged(hidden);
-        Log.d("chatFragment", "onHiddenChanged: ");
-        if (hidden == false) {
-            getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    Log.d("chatFragment", "ui update re");
-                    chatRoomAdapter.setChatRoomList(localChatRoomManager.getChatRooms());;
-                }
-            });
-
-        }
-    }
-
 
 
     @Override
@@ -87,12 +68,8 @@ public class ChatFragment extends Fragment {
         // WebSocket 연결
         webSocketViewModel.connectWebSocket();
 
-        //api client 초기화
-        chatApi = ApiManager.getInstance().createChatApi(SessionManager.getInstance().getJwtToken());
-        Log.d("chatFragment", "create api with token " + SessionManager.getInstance().getJwtToken());
-        loadChatRoomListToView(view);
-
         localChatRoomManager = localChatRoomManager.getInstance();
+        chatRoomAdapter.setChatRoomList(localChatRoomManager.getChatRooms());
         return view;
     }
 
@@ -112,7 +89,6 @@ public class ChatFragment extends Fragment {
     @Override
     public void onStart() {
         super.onStart();
-        Log.d("ChatFragment","onStart실행");
         EventBus.getDefault().register(this);
     }
 
@@ -121,13 +97,8 @@ public class ChatFragment extends Fragment {
         super.onStop();
         EventBus.getDefault().unregister(this);
     }
-
-
-
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onNewMessageArrived(NewMessageEvent event) {
-
-        // UI 업데이트 코드들을 runOnUiThread를 이용해 메인 스레드에서 실행
+    public void onChatRoomDataChange(ChatRoomDataChange event) {
         getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -135,73 +106,7 @@ public class ChatFragment extends Fragment {
                 chatRoomAdapter.setChatRoomList(localChatRoomManager.getChatRooms());
             }
         });
-
-
-
-    }
-    public void loadChatRoomListToView(View view) {
-        Log.d("chatFragment","loadChatRoomList실행중");
-        Call<UserJoinedChatRoomResponse> call = chatApi.getUserChatRooms(SessionManager.getInstance().getCurrentUser().getEmail());
-
-        call.enqueue(new Callback<UserJoinedChatRoomResponse>() {
-            @Override
-            public void onResponse(Call<UserJoinedChatRoomResponse> call, Response<UserJoinedChatRoomResponse> response) {
-                chatRoomList= extractChatRoomListFromResponse(response.code(), response.body());
-                LocalChatRoomManager.getInstance().setChatRooms(chatRoomList);
-                chatRoomAdapter.setChatRoomList(chatRoomList);// 유저가 참여중인 채팅방 리스트 api로 받은값 set
-            }
-
-            @Override
-            public void onFailure(Call<UserJoinedChatRoomResponse> call, Throwable t) {
-                Toast.makeText(getContext(), "채팅방 목록 요청에 실패하였습니다.", Toast.LENGTH_SHORT).show();
-                Log.e("API Failure", "API 호출에 실패하였습니다.", t);
-            }
-        });
-
     }
 
-    private List<ChatRoom> extractChatRoomListFromResponse(int statusCode, UserJoinedChatRoomResponse responseBody) {
-        switch (statusCode) {
-            case 200:
-                List<UserJoinedChatRoomDto> userJoinedChatRoomDtoList = responseBody.getUserJoinedChatRoomDtoList();
-                return parseDtoToChatRooms(userJoinedChatRoomDtoList);
-            default:
-                Toast.makeText(getContext(), "채팅방 목록 정보를 받아올수 없습니다.", Toast.LENGTH_SHORT).show();
-                Toast.makeText(getContext(), "code: " + statusCode, Toast.LENGTH_SHORT).show();
-
-                break;
-        }
-        return null;
-    }
-
-    private List<ChatRoom> parseDtoToChatRooms(List<UserJoinedChatRoomDto> userJoinedChatRoomDtoList) {
-        List<ChatRoom> chatRoomApiResponseList = new ArrayList<>();
-        for (UserJoinedChatRoomDto userJoinedChatRoomDto : userJoinedChatRoomDtoList) {
-            Long chatRoomId = userJoinedChatRoomDto.getChatRoomId();
-            String chatRoomName = userJoinedChatRoomDto.getChatRoomName();
-
-            List<User> userList = new ArrayList<>();
-            List<UserDto> participants = userJoinedChatRoomDto.getParticipants();
-            for (UserDto participant : participants) {
-                User user = new User(participant.getEmail(), participant.getPassword(), participant.getName(), participant.getImgUrl(), participant.getGender());
-                userList.add(user);
-            }
-
-            Optional<String> optionalLastMessage = Optional.ofNullable(userJoinedChatRoomDto.getLastMessage());
-            String lastMessage = optionalLastMessage.orElse("");
-
-            //LocalDateTime lastSentTime = userJoinedChatRoomDto.getLastSentTime();
-
-            Optional<LocalDateTime> optionalLastSentTime = Optional.ofNullable(userJoinedChatRoomDto.getLastSentTime());
-            String lastSentTimeString = optionalLastSentTime.map(LocalDateTime::toString).orElse("");
-            Integer nonReadMessageCount = userJoinedChatRoomDto.getNonReadMessageCount();
-            ChatRoom chatRoom = new ChatRoom(chatRoomId,chatRoomName,userList,lastMessage,lastSentTimeString,nonReadMessageCount);
-            Log.d("채팅방 목록",chatRoom.toString());
-            chatRoomApiResponseList.add(chatRoom);
-            // 특정 채널 구독
-            webSocketViewModel.subscribeToChannel(chatRoomId);
-        }
-        return chatRoomApiResponseList;
-    }
 
 }

--- a/app/src/main/java/com/example/spoot_taxi_front/fragments/ChatFragment.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/fragments/ChatFragment.java
@@ -8,38 +8,19 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
 
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.spoot_taxi_front.R;
-import com.example.spoot_taxi_front.models.ChatRoom;
-import com.example.spoot_taxi_front.models.User;
-import com.example.spoot_taxi_front.network.api.ChatApi;
-import com.example.spoot_taxi_front.network.dto.UserDto;
-import com.example.spoot_taxi_front.network.dto.UserJoinedChatRoomDto;
-import com.example.spoot_taxi_front.network.dto.responses.UserJoinedChatRoomResponse;
-import com.example.spoot_taxi_front.network.retrofit.ApiManager;
 import com.example.spoot_taxi_front.utils.ChatRoomDataChange;
 import com.example.spoot_taxi_front.utils.LocalChatRoomManager;
-import com.example.spoot_taxi_front.utils.NewMessageEvent;
-import com.example.spoot_taxi_front.utils.SessionManager;
 import com.example.spoot_taxi_front.adapters.ChatRoomAdapter;
-import com.example.spoot_taxi_front.utils.WebSocketViewModel;
+import com.example.spoot_taxi_front.network.socket.WebSocketViewModel;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
 
 public class ChatFragment extends Fragment {
 

--- a/app/src/main/java/com/example/spoot_taxi_front/fragments/MatchingFragment.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/fragments/MatchingFragment.java
@@ -23,22 +23,16 @@ import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
 import com.example.spoot_taxi_front.R;
-import com.example.spoot_taxi_front.models.ChatRoom;
-import com.example.spoot_taxi_front.models.User;
-import com.example.spoot_taxi_front.network.api.ChatApi;
 import com.example.spoot_taxi_front.network.api.MatchingApi;
-import com.example.spoot_taxi_front.network.dto.UserDto;
-import com.example.spoot_taxi_front.network.dto.UserJoinedChatRoomDto;
 import com.example.spoot_taxi_front.network.dto.requests.MatchCancelRequest;
 import com.example.spoot_taxi_front.network.dto.requests.MatchingRequest;
 import com.example.spoot_taxi_front.network.dto.responses.MatchCancelResponse;
 import com.example.spoot_taxi_front.network.dto.responses.MatchingResponse;
-import com.example.spoot_taxi_front.network.dto.responses.UserJoinedChatRoomResponse;
 import com.example.spoot_taxi_front.network.retrofit.ApiManager;
 import com.example.spoot_taxi_front.utils.LocalChatRoomManager;
 import com.example.spoot_taxi_front.utils.MatchingSuccessEvent;
 import com.example.spoot_taxi_front.utils.SessionManager;
-import com.example.spoot_taxi_front.utils.WebSocketViewModel;
+import com.example.spoot_taxi_front.network.socket.WebSocketViewModel;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 import net.daum.mf.map.api.CameraUpdateFactory;
@@ -49,11 +43,6 @@ import net.daum.mf.map.api.MapView.MapViewEventListener;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
 import retrofit2.Call;
 import retrofit2.Callback;

--- a/app/src/main/java/com/example/spoot_taxi_front/network/socket/WebSocketManager.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/network/socket/WebSocketManager.java
@@ -1,4 +1,4 @@
-package com.example.spoot_taxi_front.utils;
+package com.example.spoot_taxi_front.network.socket;
 
 import android.util.Log;
 
@@ -6,6 +6,9 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
 import com.example.spoot_taxi_front.models.ChatMessage;
+import com.example.spoot_taxi_front.utils.LocalChatRoomManager;
+import com.example.spoot_taxi_front.utils.NewMessageEvent;
+import com.example.spoot_taxi_front.utils.SessionManager;
 
 import org.greenrobot.eventbus.EventBus;
 import org.json.JSONException;

--- a/app/src/main/java/com/example/spoot_taxi_front/network/socket/WebSocketViewModel.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/network/socket/WebSocketViewModel.java
@@ -1,4 +1,4 @@
-package com.example.spoot_taxi_front.utils;
+package com.example.spoot_taxi_front.network.socket;
 
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModel;

--- a/app/src/main/java/com/example/spoot_taxi_front/utils/ChatRoomDataChange.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/utils/ChatRoomDataChange.java
@@ -1,4 +1,4 @@
 package com.example.spoot_taxi_front.utils;
 
-public class NonReadCountUpdateEvent {
+public class ChatRoomDataChange {
 }

--- a/app/src/main/java/com/example/spoot_taxi_front/utils/LocalChatRoomManager.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/utils/LocalChatRoomManager.java
@@ -10,6 +10,7 @@ import com.example.spoot_taxi_front.network.dto.UserDto;
 import com.example.spoot_taxi_front.network.dto.UserJoinedChatRoomDto;
 import com.example.spoot_taxi_front.network.dto.responses.UserJoinedChatRoomResponse;
 import com.example.spoot_taxi_front.network.retrofit.ApiManager;
+import com.example.spoot_taxi_front.network.socket.WebSocketViewModel;
 
 import org.greenrobot.eventbus.EventBus;
 

--- a/app/src/main/java/com/example/spoot_taxi_front/utils/LocalChatRoomManager.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/utils/LocalChatRoomManager.java
@@ -71,7 +71,7 @@ public class LocalChatRoomManager {
             }
         }
 
-        EventBus.getDefault().post(new NonReadCountUpdateEvent());
+        EventBus.getDefault().post(new ChatRoomDataChange());
     }
 
     public void nonReadCountZeroUpdate(Long chatRoomId) {
@@ -83,7 +83,7 @@ public class LocalChatRoomManager {
             }
         }
 
-        EventBus.getDefault().post(new NonReadCountUpdateEvent());
+        EventBus.getDefault().post(new ChatRoomDataChange());
     }
 
     public void exitChatRoom(Long chatRoomId) {
@@ -95,7 +95,7 @@ public class LocalChatRoomManager {
             }
         }
 
-        EventBus.getDefault().post(new NonReadCountUpdateEvent());
+        EventBus.getDefault().post(new ChatRoomDataChange());
     }
 
     public int getTotalNonReadCount() {
@@ -114,7 +114,7 @@ public class LocalChatRoomManager {
             @Override
             public void onResponse(Call<UserJoinedChatRoomResponse> call, Response<UserJoinedChatRoomResponse> response) {
                 chatRooms = extractChatRoomListFromResponse(response.code(), response.body());
-                EventBus.getDefault().post(new NonReadCountUpdateEvent());
+                EventBus.getDefault().post(new ChatRoomDataChange());
             }
 
             @Override

--- a/app/src/main/java/com/example/spoot_taxi_front/utils/LocalChatRoomManager.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/utils/LocalChatRoomManager.java
@@ -25,7 +25,6 @@ import retrofit2.Response;
 public class LocalChatRoomManager {
 
     private static LocalChatRoomManager instance;
-
     private List<ChatRoom> chatRooms = new ArrayList<>();
     private ChatApi chatApi;
     private WebSocketViewModel webSocketViewModel;
@@ -115,6 +114,7 @@ public class LocalChatRoomManager {
             @Override
             public void onResponse(Call<UserJoinedChatRoomResponse> call, Response<UserJoinedChatRoomResponse> response) {
                 chatRooms = extractChatRoomListFromResponse(response.code(), response.body());
+                EventBus.getDefault().post(new NonReadCountUpdateEvent());
             }
 
             @Override

--- a/app/src/main/java/com/example/spoot_taxi_front/utils/NonReadCountUpdateEvent.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/utils/NonReadCountUpdateEvent.java
@@ -1,0 +1,4 @@
+package com.example.spoot_taxi_front.utils;
+
+public class NonReadCountUpdateEvent {
+}


### PR DESCRIPTION
## 수행한 작업들 
### 1. 바텀 네비게이션 챗 아이콘 옆에 안읽은 메시지 수 띄우기
![image](https://github.com/Libienz/Spoot-Taxi-FrontEnd/assets/85234650/8e2d399d-37cf-42b6-a284-416ca8dab012)

### 2. LocalChatRoomManager 범위 및 역할 구체화를 통한 refactor
- 챗룸을 서버로부터 로드하는 것도 LocalChatRoomManager가 일임
https://github.com/Libienz/Spoot-Taxi-FrontEnd/blob/0cb1f070fc915a40d3e6a23fee9f9f6a5402fcfc/app/src/main/java/com/example/spoot_taxi_front/fragments/ChatFragment.java#L25-L93

- 챗프래그먼트 코드 많이 짧아짐
- 프래그먼트는 그냥 로컬 값이 변경되었을 때 로컬 매니저의 값으로만 업데이트 한다 
- onHidden도 전부 필요없음 로컬 값이 바뀐 것을 감지하면 이벤트 발행하고 이벤트를 감지한 프래그먼트는 뷰를 업데이트 한다

### 3. 자잘한 delete 등등..


 
