### PR TITLE
PR: 알림권한 및 웹소켓 재연결 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/app/src/main/java/com/example/spoot_taxi_front/activities/ChatRoomActivity.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/activities/ChatRoomActivity.java
@@ -209,6 +209,14 @@ public class ChatRoomActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        if(webSocketViewModel.isConnected()){
+            Log.d("resumeConnect","연결되어있어요");
+        }
+        if(!webSocketViewModel.isConnected()){
+            Log.d("resumeDisConnect","비연결되어있어요");
+            webSocketViewModel.reconnect();
+            LocalChatRoomManager.getInstance().loadChatRoomsFromServer();
+        }
         scrollToBottom();
     }
 

--- a/app/src/main/java/com/example/spoot_taxi_front/network/socket/WebSocketManager.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/network/socket/WebSocketManager.java
@@ -31,6 +31,7 @@ public class WebSocketManager {
 
     // 구독한 주소와 해당 구독의 Disposable을 매핑하는 Map을 사용
     Map<String, Disposable> subscriptionMap = new HashMap<>();
+    private static final String WEBSOCKET_URL = "ws://192.168.219.106:8090/ws/websocket";
     private WebSocketManager() {
         // Private constructor to prevent external instantiation
     }
@@ -41,6 +42,17 @@ public class WebSocketManager {
         return instance;
     }
 
+    public StompClient getStompClient() {
+        return stompClient;
+    }
+
+    public void reconnect(){
+        connectWebSocket();
+        subscriptionMap.clear();
+    }
+    public boolean isConnected(){
+        return stompClient.isConnected();
+    }
     // 웹소켓 메시지를 받아오는 콜백을 처리하는 메서드
     private void handleMessage(ChatMessage chatMessage) {
         Log.d("핸들메세지","잘되나");
@@ -60,10 +72,15 @@ public class WebSocketManager {
     public StompClient connectWebSocket() {
         if (stompClient == null) {
 //            stompClient = Stomp.over(Stomp.ConnectionProvider.OKHTTP, "ws://10.0.2.2:8080/ws/websocket");
-            stompClient = Stomp.over(Stomp.ConnectionProvider.OKHTTP, "ws://192.168.219.110:8090/ws/websocket");
+            Log.d("stompClientNull", "null임");
+            stompClient = Stomp.over(Stomp.ConnectionProvider.OKHTTP, WEBSOCKET_URL);
             stompClient.connect();
         }
-
+        else if (stompClient != null && !stompClient.isConnected()) {
+            Log.d("stompClientNotNull", stompClient.toString());
+            stompClient = Stomp.over(Stomp.ConnectionProvider.OKHTTP, WEBSOCKET_URL);
+            stompClient.connect();
+        }
         return stompClient;
     }
 

--- a/app/src/main/java/com/example/spoot_taxi_front/network/socket/WebSocketViewModel.java
+++ b/app/src/main/java/com/example/spoot_taxi_front/network/socket/WebSocketViewModel.java
@@ -7,6 +7,8 @@ import com.example.spoot_taxi_front.models.ChatMessage;
 
 import org.json.JSONObject;
 
+import ua.naiksoftware.stomp.StompClient;
+
 public class WebSocketViewModel extends ViewModel {
     private static WebSocketViewModel instance;
     private WebSocketManager webSocketManager = WebSocketManager.getInstance();
@@ -16,6 +18,16 @@ public class WebSocketViewModel extends ViewModel {
             instance = new WebSocketViewModel();
         }
         return instance;
+    }
+
+    public void reconnect(){
+        webSocketManager.reconnect();
+    }
+    public boolean isConnected(){
+        return webSocketManager.isConnected();
+    }
+    public StompClient getStompClient() {
+        return webSocketManager.getStompClient();
     }
 
     public void connectWebSocket() {


### PR DESCRIPTION
**알림 권한 요청 수행하기**
- MainActicity에서 requestNotificationPermission();로 onCreate되는시점에 알림권한을 받는다.
- 안드로이드12이하는 기본설정이 알림이 허용된 상태지만 허용이 안된상태일때 설정으로 보내주고 바꾸게 유도.(showNotificationSettingAlert메소드와 openNotificationSettings참조)
- 안드로이드13부터 기본설정이 알림 거부이기때문에 런타임 알림퍼미션을 통해 설정하도록 유도. (requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS); 참조)

**웹소켓 연결 끊어지는 시점과 재연결 시점 명확히 하기 (특히 어플리케이션이 백그라운드로 내려가는 경우를 조심 )**
- 현재 확인된 바로는 전원버튼을 누르거나, 홈버튼을 눌러서 백그라운드에 오래 있는경우 자동적으로 웹소켓이 해제가된다.
- onResume메소드는 백그라운드에서 포그라운드로 전환될때나 액티비티가 다시불리는경우 실행되는데 이걸 통해 해결하기로 결심
- 만약 웹소켓이 연결되어있다면 로그만찍고 넘어가고 연결이 되어있지않다면 재연결한뒤 해제된 구독도 다시 해주는 방식.
- **ChatRoomActivity**와 **MainActivity**의 onResume메소드만 설정해주면 된다. 
- Why? 채팅을 하기위해선 MainActivity의 ChatFragment를 지나야하기때문이고. ChatRoomActivity에서 해제된경우를 추가로 생각하면 2군데면 충분하다.
- 물론 이러면 다른 Activity에서 끊어진경우는 알림같은걸 못받는경우가 생길수는 있을것.